### PR TITLE
Updating releaseEXT

### DIFF
--- a/dev/td-modules/base_save_for_release/releaseEXT.py
+++ b/dev/td-modules/base_save_for_release/releaseEXT.py
@@ -56,8 +56,10 @@ class PackageTOX:
 		target_op.color = self.Reset_color
 
 		# lock the tox icon 
-		target_op.op('null_icon').lock = True
-
+		try:
+			target_op.op('null_icon').lock = True
+		except:
+			pass
 		# destory ops used for Dev
 		destory_tags 				= self.Destory_tags.val.split(',')
 		ops_to_destory 				= target_op.findChildren(tags=destory_tags)
@@ -82,6 +84,7 @@ class PackageTOX:
 			each.par.file 			= ''
 			# turn off loading on start
 			each.par.loadonstart 	= False
+			each.par.syncfile 		= False
 	
 		return ops_to_prep
 	


### PR DESCRIPTION
I added a try / catch block around the below line in the situation you don't want to use an icon.  I'm releasing an app and just want to show my GUI - 
`			target_op.op('null_icon').lock = True
`

Same update as before  - 
`
each.par.syncfile 		= False
`